### PR TITLE
feat: IETF Payment session intent

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,0 +1,81 @@
+# Compliance Posture
+
+toll-booth is **middleware** — a software library that operators deploy in front of their own APIs. It is not a financial service, exchange, custodian, or money transmitter.
+
+## Operator Responsibility
+
+**Operators deploying toll-booth are solely responsible for their own regulatory compliance**, including but not limited to:
+
+- Money transmitter licensing (US FinCEN MSB, state MTLs)
+- Crypto-asset service provider authorisation (EU MiCA CASP)
+- Anti-money laundering programme (KYC/AML)
+- Data protection (GDPR, UK GDPR, CCPA)
+- Tax reporting obligations (DAC8, Form 1099-DA, OECD CARF)
+- Sanctions screening (OFAC, EU, UN sanctions lists)
+
+toll-booth provides building blocks (geo-fencing, audit events, data minimisation) but does not constitute a compliance programme.
+
+## Data Handling
+
+### Personal Data
+
+toll-booth collects **minimal data** by design:
+
+| Data | Stored? | How |
+|------|---------|-----|
+| Client IP address | Hashed only | SHA-256 with daily-rotating salt. Raw IP never persisted. |
+| Payment hashes | Yes | Pseudonymous Lightning identifiers. Not PII. |
+| Bearer tokens | Session lifetime only | Server-generated opaque values. Deleted on session close. |
+| Return invoices | Session lifetime only | BOLT11 routing info. No identity data. |
+
+No user accounts, emails, names, or identity data are collected.
+
+### Data Retention
+
+- **Invoices:** Pruned hourly, default 24-hour retention (`invoiceMaxAgeMs`)
+- **Sessions:** Pruned hourly after close, same retention period
+- **Settlement markers:** Retained permanently (replay prevention — cryptographic necessity)
+- **Free-tier IP hashes:** In-memory only, reset daily, capped at 100,000 entries
+
+### GDPR Assessment
+
+For typical deployments where toll-booth processes only hashed IPs and Lightning payment hashes, a full DPIA is unlikely to be required. However, operators who combine toll-booth with additional user data collection should conduct their own assessment.
+
+## Session Intent — Custody Considerations
+
+The session intent introduces **temporary custody**: the server holds a Lightning deposit and refunds unspent balance on close. Compliance guardrails are built in:
+
+| Guardrail | Config | Default |
+|-----------|--------|---------|
+| Maximum session duration | `maxSessionDurationMs` | 24 hours |
+| Maximum deposit amount | `maxDepositSats` | 100,000 sats |
+| Auto-close expired sessions | Automatic (hourly sweep) | Enabled |
+| Refund-to-originator only | Enforced in code | Always |
+
+Operators using the session intent should assess whether temporary custody triggers licensing requirements in their jurisdiction. For small-value, short-duration API metering, enforcement risk is low in most jurisdictions, but this is not legal advice.
+
+## Geo-Fencing
+
+toll-booth includes an OFAC sanctions country list (`OFAC_SANCTIONED`) as a starting point:
+
+- Cuba (CU), Iran (IR), North Korea (KP), Syria (SY), Russia (RU)
+
+**This is a point-in-time snapshot. Operators must:**
+- Verify against the current OFAC SDN list
+- Add jurisdictions required by their applicable sanctions regime (e.g. UK OFSI, EU)
+- Configure via `blockedCountries` in BoothConfig
+
+## Audit Events
+
+toll-booth emits structured events via the `EventHandler` interface:
+
+- `onPayment` — payment received (hash, amount, rail, timestamp)
+- `onRequest` — authenticated request (endpoint, cost, balance, latency)
+- `onChallenge` — 402 challenge issued (endpoint, amount)
+- `onSessionEvent` — session lifecycle (open, close, expire, topup, deduct)
+
+Operators should persist these events according to their retention requirements (typically 5 years for AML-regulated entities).
+
+## Disclaimer
+
+This document describes toll-booth's technical compliance features, not legal compliance. It does not constitute legal advice. Operators should consult qualified legal counsel for their specific regulatory obligations.

--- a/MISSION.md
+++ b/MISSION.md
@@ -6,7 +6,7 @@ The web's payment layer was built for humans. Sign-up forms, credit cards, billi
 
 toll-booth turns any HTTP API into a vending machine. One middleware. Multiple payment rails - Lightning, Cashu ecash, x402 stablecoins, IETF Payment, Nostr Wallet Connect. The API operator picks which to accept. The client picks which to use. Neither needs permission from the other.
 
-toll-booth is the foundation of a stack for machine-to-machine commerce. [satgate](https://github.com/forgesworn/satgate) builds on it to monetise AI inference. [402-mcp](https://github.com/forgesworn/402-mcp) gives AI agents the ability to discover and pay for toll-booth-protected APIs autonomously. Together, they close the loop: any API can charge, any agent can pay.
+toll-booth is the foundation of a stack for machine-to-machine commerce. [satgate](https://github.com/TheCryptoDonkey/satgate) builds on it to monetise AI inference. [402-mcp](https://github.com/forgesworn/402-mcp) gives AI agents the ability to discover and pay for toll-booth-protected APIs autonomously. Together, they close the loop: any API can charge, any agent can pay.
 
 We believe:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Your API earns money the moment it receives a request. Clients pay with Lightnin
 
 ## See it in production
 
-[**satgate**](https://github.com/forgesworn/satgate) is a pay-per-token AI inference proxy built on toll-booth. It monetises any OpenAI-compatible endpoint — Ollama, vLLM, llama.cpp — with one command. Token counting, model pricing, streaming reconciliation, capacity management. Everything else — payments, credits, free tier, macaroon auth — is toll-booth.
+[**satgate**](https://github.com/TheCryptoDonkey/satgate) is a pay-per-token AI inference proxy built on toll-booth. It monetises any OpenAI-compatible endpoint — Ollama, vLLM, llama.cpp — with one command. Token counting, model pricing, streaming reconciliation, capacity management. Everything else — payments, credits, free tier, macaroon auth — is toll-booth.
 
 ~400 lines of product logic on top of the middleware. That's what "monetise any API with one line of code" looks like in practice.
 
@@ -496,7 +496,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference includ
 | Project | Role |
 |---------|------|
 | **[toll-booth](https://github.com/forgesworn/toll-booth)** | **Payment-rail agnostic HTTP 402 middleware** |
-| [satgate](https://github.com/forgesworn/satgate) | Production showcase — pay-per-token AI inference proxy (~400 lines on toll-booth) |
+| [satgate](https://github.com/TheCryptoDonkey/satgate) | Production showcase — pay-per-token AI inference proxy (~400 lines on toll-booth) |
 | [402-mcp](https://github.com/forgesworn/402-mcp) | Client side — AI agents discover, pay, and consume L402 APIs |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,7 +201,7 @@ graph TB
 | Layer | Project | What it does | What it doesn't do |
 |-------|---------|-------------|-------------------|
 | **Client** | [402-mcp](https://github.com/forgesworn/402-mcp) | Discovers, pays, consumes L402 APIs | Doesn't gate or price anything |
-| **Product** | [satgate](https://github.com/forgesworn/satgate) | Token counting, model pricing, capacity, streaming | Doesn't handle payments directly |
+| **Product** | [satgate](https://github.com/TheCryptoDonkey/satgate) | Token counting, model pricing, capacity, streaming | Doesn't handle payments directly |
 | **Middleware** | [toll-booth](https://github.com/forgesworn/toll-booth) | Payment gating, credit accounting, free tiers | Doesn't know about tokens or models |
 | **Rails** | Lightning / Cashu / NWC / x402 | Moves money | Doesn't know about HTTP or APIs |
 

--- a/docs/case-studies/satgate.md
+++ b/docs/case-studies/satgate.md
@@ -8,7 +8,7 @@ Flat-rate pricing does not work either. A 20-token completion and a 4,000-token 
 
 ## The solution
 
-[satgate](https://github.com/forgesworn/satgate) is a reverse proxy that sits in front of any OpenAI-compatible inference endpoint. It uses toll-booth for all payment infrastructure and adds token counting, model-specific pricing, and streaming reconciliation on top. The entire product is roughly 400 lines of application logic; everything else - payment gating, credit accounting, free tiers, macaroon authentication, persistence - is toll-booth.
+[satgate](https://github.com/TheCryptoDonkey/satgate) is a reverse proxy that sits in front of any OpenAI-compatible inference endpoint. It uses toll-booth for all payment infrastructure and adds token counting, model-specific pricing, and streaming reconciliation on top. The entire product is roughly 400 lines of application logic; everything else - payment gating, credit accounting, free tiers, macaroon authentication, persistence - is toll-booth.
 
 One command turns your local model into a paid API. No accounts. No sign-up. No billing dashboard.
 
@@ -68,7 +68,7 @@ If you are building a paid API, you probably do not need to write payment code a
 
 ## Links
 
-- **satgate:** [github.com/forgesworn/satgate](https://github.com/forgesworn/satgate)
+- **satgate:** [github.com/TheCryptoDonkey/satgate](https://github.com/TheCryptoDonkey/satgate)
 - **toll-booth:** [github.com/forgesworn/toll-booth](https://github.com/forgesworn/toll-booth)
 - **402-mcp:** [github.com/forgesworn/402-mcp](https://github.com/forgesworn/402-mcp)
 - **Live:** [satgate.trotters.dev](https://satgate.trotters.dev)

--- a/docs/guides/ollama-monetisation.md
+++ b/docs/guides/ollama-monetisation.md
@@ -171,7 +171,7 @@ The `X-Credit-Balance` response header shows remaining sats.
 
 ## For production
 
-This flat-rate approach works for simple cases, but AI inference varies wildly per request. A short completion might use 50 tokens; a long one might use 4,000. For production deployments, look at [**satgate**](https://github.com/forgesworn/satgate) - a production-grade inference gateway built on toll-booth (~400 lines) that adds:
+This flat-rate approach works for simple cases, but AI inference varies wildly per request. A short completion might use 50 tokens; a long one might use 4,000. For production deployments, look at [**satgate**](https://github.com/TheCryptoDonkey/satgate) - a production-grade inference gateway built on toll-booth (~400 lines) that adds:
 
 - **Per-token metering** - charges based on actual token usage, not flat rates
 - **Streaming reconciliation** - counts tokens in real-time SSE streams

--- a/docs/nip-402.md
+++ b/docs/nip-402.md
@@ -239,4 +239,4 @@ Clients MAY maintain whitelists or reputation scores for trusted service provide
 - [402-announce](https://github.com/forgesworn/402-announce) - Kind 31402 event publisher (TypeScript)
 - [402-mcp](https://github.com/forgesworn/402-mcp) - AI agent discovery client (TypeScript)
 - [toll-booth](https://github.com/forgesworn/toll-booth) - L402/x402 payment middleware (TypeScript)
-- [satgate](https://github.com/forgesworn/satgate) - Lightning-paid AI inference gateway (TypeScript)
+- [satgate](https://github.com/TheCryptoDonkey/satgate) - Lightning-paid AI inference gateway (TypeScript)

--- a/docs/x-article.md
+++ b/docs/x-article.md
@@ -12,7 +12,7 @@ A wide cinematic scene of a futuristic toll booth on an elevated highway at nigh
 
 ## Article
 
-In 1999, the architects of the web reserved HTTP status code 402 -Payment Required. It was a placeholder for a future where the internet had native payments. Twenty-five years later, we still don't use it.
+In 1999, the architects of the web reserved HTTP status code 402 -Payment Required. It was a placeholder for a future where the internet had native payments. Twenty-seven years later, we still don't use it.
 
 Every API on the web assumes you're a human with a credit card. Sign up. Get a key. Add a billing method. Wait for approval. This works fine when the consumer is a developer at a desk. It falls apart completely when the consumer is an autonomous AI agent that needs to call your API at 3am.
 
@@ -73,7 +73,7 @@ Three payment rails. One middleware. The client picks.
 
 ### Not vapourware
 
-toll-booth is running in production right now. It gates a Valhalla routing engine at routing.trotters.cc -real Lightning invoices, real payments, real map queries returned.
+toll-booth is running in production right now. It gates a joke API at jokes.trotters.dev and an AI inference gateway at satgate.trotters.dev -real Lightning invoices, real payments, real responses.
 
 It includes a free tier for discovery (configurable daily allowance per IP), volume discount tiers for committed users, and a self-service payment page with QR codes and wallet adapter buttons.
 

--- a/src/backends/cln.ts
+++ b/src/backends/cln.ts
@@ -80,5 +80,22 @@ export function clnBackend(config: ClnConfig): LightningBackend {
         preimage: inv.payment_preimage,
       }
     },
+
+    async sendPayment(bolt11: string): Promise<{ preimage: string }> {
+      const res = await fetch(`${baseUrl}/v1/pay`, {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bolt11 }),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`CLN sendPayment failed (${res.status}): ${text.slice(0, 200)}`)
+      }
+
+      const data = await res.json() as { payment_preimage: string }
+      return { preimage: data.payment_preimage }
+    },
   }
 }

--- a/src/backends/lnbits.ts
+++ b/src/backends/lnbits.ts
@@ -72,5 +72,35 @@ export function lnbitsBackend(config: LNbitsConfig): LightningBackend {
         preimage: data.paid ? data.preimage : undefined,
       }
     },
+
+    async sendPayment(bolt11: string): Promise<{ preimage: string }> {
+      const res = await fetch(`${baseUrl}/api/v1/payments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ out: true, bolt11 }),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`LNbits sendPayment failed (${res.status}): ${text.slice(0, 200)}`)
+      }
+
+      const payData = await res.json() as { checking_id: string; payment_hash: string }
+
+      // Look up the completed payment to retrieve the preimage
+      const detailRes = await fetch(`${baseUrl}/api/v1/payments/${payData.checking_id}`, {
+        headers: { 'X-Api-Key': config.apiKey },
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!detailRes.ok) {
+        const text = await detailRes.text().catch(() => '')
+        throw new Error(`LNbits sendPayment detail lookup failed (${detailRes.status}): ${text.slice(0, 200)}`)
+      }
+
+      const detail = await detailRes.json() as { details: { preimage: string } }
+      return { preimage: detail.details.preimage }
+    },
   }
 }

--- a/src/backends/lnd.ts
+++ b/src/backends/lnd.ts
@@ -75,5 +75,43 @@ export function lndBackend(config: LndConfig): LightningBackend {
           : undefined,
       }
     },
+
+    async sendPayment(bolt11: string): Promise<{ preimage: string }> {
+      const res = await fetch(`${baseUrl}/v2/router/send`, {
+        method: 'POST',
+        headers: {
+          'Grpc-Metadata-macaroon': macaroonHex,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ payment_request: bolt11, timeout_seconds: 30 }),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`LND sendPayment failed (${res.status}): ${text.slice(0, 200)}`)
+      }
+
+      // v2/router/send returns newline-delimited JSON (streaming).
+      // Each line is a payment status update; we want the final one.
+      const text = await res.text()
+      const lines = text.trim().split('\n').filter(Boolean)
+
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const entry = JSON.parse(lines[i]) as {
+          result?: { status?: string; payment_preimage?: string }
+        }
+        if (entry.result?.status === 'SUCCEEDED' && entry.result.payment_preimage) {
+          return {
+            preimage: Buffer.from(entry.result.payment_preimage, 'base64').toString('hex'),
+          }
+        }
+        if (entry.result?.status === 'FAILED') {
+          throw new Error('LND sendPayment: payment failed')
+        }
+      }
+
+      throw new Error('LND sendPayment: no successful payment result in response')
+    },
   }
 }

--- a/src/backends/lnd.ts
+++ b/src/backends/lnd.ts
@@ -98,8 +98,11 @@ export function lndBackend(config: LndConfig): LightningBackend {
       const lines = text.trim().split('\n').filter(Boolean)
 
       for (let i = lines.length - 1; i >= 0; i--) {
-        const entry = JSON.parse(lines[i]) as {
-          result?: { status?: string; payment_preimage?: string }
+        let entry: { result?: { status?: string; payment_preimage?: string } }
+        try {
+          entry = JSON.parse(lines[i])
+        } catch {
+          continue // skip malformed JSON lines (network truncation)
         }
         if (entry.result?.status === 'SUCCEEDED' && entry.result.payment_preimage) {
           return {

--- a/src/backends/nwc.ts
+++ b/src/backends/nwc.ts
@@ -78,5 +78,14 @@ export function nwcBackend(config: NwcConfig): LightningBackend {
         return { paid: false }
       }
     },
+
+    async sendPayment(bolt11: string): Promise<{ preimage: string }> {
+      const nwc = await getClient()
+      const result = await nwc.payInvoice(bolt11)
+      if (!result.preimage) {
+        throw new Error('NWC sendPayment: response missing preimage')
+      }
+      return { preimage: result.preimage }
+    },
   }
 }

--- a/src/backends/nwc.ts
+++ b/src/backends/nwc.ts
@@ -81,7 +81,11 @@ export function nwcBackend(config: NwcConfig): LightningBackend {
 
     async sendPayment(bolt11: string): Promise<{ preimage: string }> {
       const nwc = await getClient()
-      const result = await nwc.payInvoice(bolt11)
+      const timeoutMs = timeout ?? 60_000
+      const timer = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('NWC sendPayment: timed out')), timeoutMs),
+      )
+      const result = await Promise.race([nwc.payInvoice(bolt11), timer])
       if (!result.preimage) {
         throw new Error('NWC sendPayment: response missing preimage')
       }

--- a/src/backends/phoenixd.ts
+++ b/src/backends/phoenixd.ts
@@ -71,5 +71,28 @@ export function phoenixdBackend(config: PhoenixdConfig): LightningBackend {
         preimage: data.isPaid ? data.preimage : undefined,
       }
     },
+
+    async sendPayment(bolt11: string): Promise<{ preimage: string }> {
+      const body = new URLSearchParams()
+      body.set('invoice', bolt11)
+
+      const res = await fetch(`${baseUrl}/payinvoice`, {
+        method: 'POST',
+        headers: {
+          'Authorization': authHeader,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`Phoenixd payinvoice failed (${res.status}): ${text.slice(0, 200)}`)
+      }
+
+      const data = await res.json() as { paymentPreimage: string }
+      return { preimage: data.paymentPreimage }
+    },
   }
 }

--- a/src/core/ietf-session.test.ts
+++ b/src/core/ietf-session.test.ts
@@ -271,6 +271,233 @@ describe('IETF Session Rail', () => {
       expect(closeResult.customCaveats?.['X-Session-Closed']).toBe('true')
     })
 
+    it('closes an already-closed session gracefully (close replay)', async () => {
+      const rail = createRail()
+      const { result } = await openSession(rail)
+      const bearerToken = result.customCaveats!['X-Session-Token']
+      const sessionId = result.customCaveats!['X-Session-Id']
+
+      // Close via storage directly
+      storage.closeSession(sessionId)
+
+      // Attempting to close again via the rail should fail gracefully (not throw)
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const closeCredential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'close',
+          sessionToken: bearerToken,
+        } satisfies SessionClosePayload,
+      }
+
+      const closeResult = await rail.verify(makeRequest(encodeCredential(closeCredential)))
+      // Should return unauthenticated (session already closed), not throw
+      expect(closeResult.authenticated).toBe(false)
+    })
+
+    it('skips refund gracefully when no returnInvoice was provided', async () => {
+      const rail = createRail()
+
+      // Open a session without a returnInvoice
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const openCredential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'open',
+          preimage: entry.preimage,
+          // No returnInvoice
+        } satisfies SessionOpenPayload,
+      }
+
+      const openResult = await rail.verify(makeRequest(encodeCredential(openCredential)))
+      expect(openResult.authenticated).toBe(true)
+      const bearerToken = openResult.customCaveats!['X-Session-Token']
+
+      // Spy on sendPayment to ensure it is NOT called
+      const sendPaymentSpy = vi.spyOn(backend, 'sendPayment' as any)
+
+      // Close the session — refund should be skipped (no return invoice)
+      const closeFragment = await rail.challenge('/api/test', { sats: 500 })
+      const closeWwwAuth = closeFragment.headers['WWW-Authenticate']
+      const closeIdMatch = closeWwwAuth.match(/id="([^"]+)"/)!
+      const closeRequestMatch = closeWwwAuth.match(/request="([^"]+)"/)!
+      const closeExpiresMatch = closeWwwAuth.match(/expires="([^"]+)"/)!
+
+      const closeCredential: IETFCredential = {
+        challenge: {
+          id: closeIdMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: closeRequestMatch[1],
+          expires: closeExpiresMatch[1],
+        },
+        payload: {
+          action: 'close',
+          sessionToken: bearerToken,
+        } satisfies SessionClosePayload,
+      }
+
+      const closeResult = await rail.verify(makeRequest(encodeCredential(closeCredential)))
+      expect(closeResult.authenticated).toBe(true)
+      expect(closeResult.customCaveats?.['X-Session-Closed']).toBe('true')
+      expect(sendPaymentSpy).not.toHaveBeenCalled()
+
+      sendPaymentSpy.mockRestore()
+    })
+
+    it('still closes session even if sendPayment fails during refund', async () => {
+      // Create a backend where sendPayment throws
+      const failingBackend: LightningBackend = {
+        async createInvoice(amountSats: number, memo?: string) {
+          return backend.createInvoice(amountSats, memo)
+        },
+        async checkInvoice(paymentHash: string) {
+          return backend.checkInvoice(paymentHash)
+        },
+        async sendPayment(_bolt11: string) {
+          throw new Error('Lightning node unreachable')
+        },
+      }
+
+      const rail = createIETFSessionRail({
+        hmacSecret: HMAC_SECRET,
+        realm: REALM,
+        backend: failingBackend,
+        storage,
+        session: sessionConfig,
+      })
+
+      // Open a session with a returnInvoice
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const openCredential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'open',
+          preimage: entry.preimage,
+          returnInvoice: 'lnbc1testreturn',
+        } satisfies SessionOpenPayload,
+      }
+
+      const openResult = await rail.verify(makeRequest(encodeCredential(openCredential)))
+      expect(openResult.authenticated).toBe(true)
+      const bearerToken = openResult.customCaveats!['X-Session-Token']
+
+      // Close the session — sendPayment will throw, but close should still succeed
+      const closeFragment = await rail.challenge('/api/test', { sats: 500 })
+      const closeWwwAuth = closeFragment.headers['WWW-Authenticate']
+      const closeIdMatch = closeWwwAuth.match(/id="([^"]+)"/)!
+      const closeRequestMatch = closeWwwAuth.match(/request="([^"]+)"/)!
+      const closeExpiresMatch = closeWwwAuth.match(/expires="([^"]+)"/)!
+
+      const closeCredential: IETFCredential = {
+        challenge: {
+          id: closeIdMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: closeRequestMatch[1],
+          expires: closeExpiresMatch[1],
+        },
+        payload: {
+          action: 'close',
+          sessionToken: bearerToken,
+        } satisfies SessionClosePayload,
+      }
+
+      // Should not throw — close succeeds even though refund fails
+      const closeResult = await rail.verify(makeRequest(encodeCredential(closeCredential)))
+      expect(closeResult.authenticated).toBe(true)
+      expect(closeResult.customCaveats?.['X-Session-Closed']).toBe('true')
+      // No refund preimage since sendPayment failed
+      expect(closeResult.customCaveats?.['X-Refund-Preimage']).toBeUndefined()
+    })
+
+    it('accepts top-up with same preimage as deposit (different challenge)', async () => {
+      const rail = createRail()
+      const { result } = await openSession(rail)
+      const bearerToken = result.customCaveats!['X-Session-Token']
+
+      // Get a new challenge for the top-up
+      const topupFragment = await rail.challenge('/api/test', { sats: 200 })
+      const topupWwwAuth = topupFragment.headers['WWW-Authenticate']
+      const topupIdMatch = topupWwwAuth.match(/id="([^"]+)"/)!
+      const topupRequestMatch = topupWwwAuth.match(/request="([^"]+)"/)!
+      const topupExpiresMatch = topupWwwAuth.match(/expires="([^"]+)"/)!
+
+      const topupSessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(topupRequestMatch[1], 'base64url').toString()
+      )
+      const topupEntry = invoiceMap.get(topupSessionRequest.deposit.paymentHash)!
+
+      const topupCredential: IETFCredential = {
+        challenge: {
+          id: topupIdMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: topupRequestMatch[1],
+          expires: topupExpiresMatch[1],
+        },
+        payload: {
+          action: 'topup',
+          sessionToken: bearerToken,
+          preimage: topupEntry.preimage,
+        } satisfies SessionTopUpPayload,
+      }
+
+      const topupResult = await rail.verify(makeRequest(encodeCredential(topupCredential)))
+      expect(topupResult.authenticated).toBe(true)
+      // Original deposit was 500, top-up is 200
+      expect(topupResult.creditBalance).toBe(700)
+    })
+
     it('rejects bearer token after close', async () => {
       const rail = createRail()
       const { result, sessionRequest } = await openSession(rail)
@@ -504,6 +731,142 @@ describe('IETF Session Rail', () => {
       }
 
       const result = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(result.authenticated).toBe(false)
+    })
+
+    it('rejects duplicate session open (replay of same deposit preimage)', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const credential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+      }
+
+      // First open succeeds
+      const first = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(first.authenticated).toBe(true)
+
+      // Replay of same credential should fail (session already exists)
+      const second = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(second.authenticated).toBe(false)
+    })
+
+    it('rejects expired challenge on open', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      // Build credential with an expires in the past and a valid HMAC
+      const pastExpires = new Date(Date.now() - 60_000).toISOString()
+      const params: IETFChallengeParams = {
+        realm: REALM,
+        method: 'lightning',
+        intent: 'session',
+        request: requestMatch[1],
+        expires: pastExpires,
+      }
+      const id = computeChallengeId(HMAC_SECRET, params)
+
+      const credential: IETFCredential = {
+        challenge: {
+          id,
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: pastExpires,
+        },
+        payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+      }
+
+      const result = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(result.authenticated).toBe(false)
+    })
+
+    it('rejects bearer auth on expired session', async () => {
+      const shortConfig: SessionConfig = {
+        maxSessionDurationMs: 1, // Expires immediately
+        maxDepositSats: 10_000,
+      }
+      const rail = createIETFSessionRail({
+        hmacSecret: HMAC_SECRET,
+        realm: REALM,
+        backend,
+        storage,
+        session: shortConfig,
+      })
+
+      // Open a session
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const credential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'open',
+          preimage: entry.preimage,
+        } satisfies SessionOpenPayload,
+      }
+
+      const openResult = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(openResult.authenticated).toBe(true)
+      const bearerToken = openResult.customCaveats!['X-Session-Token']
+
+      // Wait for session to expire
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Bearer auth should now be rejected
+      const bearerCredential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: bearerToken } satisfies SessionBearerPayload,
+      }
+      const bearerResult = await rail.verify(makeRequest(encodeCredential(bearerCredential)))
+      expect(bearerResult.authenticated).toBe(false)
+    })
+
+    it('returns unauthenticated for malformed base64url in Authorization header', async () => {
+      const rail = createRail()
+      // Not valid base64url — contains characters that will produce invalid JSON
+      const malformedAuth = 'Payment !!!not-valid-base64url@@@'
+      const result = await rail.verify(makeRequest(malformedAuth))
       expect(result.authenticated).toBe(false)
     })
 

--- a/src/core/ietf-session.test.ts
+++ b/src/core/ietf-session.test.ts
@@ -188,7 +188,7 @@ describe('IETF Session Rail', () => {
       const { result } = await openSession(rail)
 
       expect(result.authenticated).toBe(true)
-      expect(result.mode).toBe('credit')
+      expect(result.mode).toBe('session')
       expect(result.creditBalance).toBe(500)
       expect(result.customCaveats?.['X-Session-Token']).toBeDefined()
       expect(result.customCaveats?.['X-Session-Id']).toBeDefined()
@@ -209,7 +209,7 @@ describe('IETF Session Rail', () => {
       const bearerResult = await rail.verify(makeRequest(bearerAuth))
 
       expect(bearerResult.authenticated).toBe(true)
-      expect(bearerResult.mode).toBe('credit')
+      expect(bearerResult.mode).toBe('session')
       expect(bearerResult.creditBalance).toBe(500)
     })
 

--- a/src/core/ietf-session.test.ts
+++ b/src/core/ietf-session.test.ts
@@ -1,0 +1,546 @@
+// src/core/ietf-session.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createHash, randomBytes } from 'node:crypto'
+import { memoryStorage } from '../storage/memory.js'
+import { createIETFSessionRail } from './ietf-session.js'
+import type { LightningBackend, SessionConfig } from '../types.js'
+import type { StorageBackend } from '../storage/interface.js'
+import type { TollBoothRequest } from './types.js'
+import { computeChallengeId, encodeJCS } from './ietf-payment.js'
+import type { IETFChallengeParams, IETFCredential } from './ietf-payment.js'
+import type { SessionChallengeRequest, SessionOpenPayload, SessionBearerPayload, SessionClosePayload, SessionTopUpPayload } from './ietf-session.js'
+
+// --- Test helpers ---
+
+const HMAC_SECRET = randomBytes(32).toString('hex')
+const REALM = 'test.example.com'
+
+function makePreimage(): { preimage: string; paymentHash: string } {
+  const preimage = randomBytes(32).toString('hex')
+  const paymentHash = createHash('sha256').update(Buffer.from(preimage, 'hex')).digest('hex')
+  return { preimage, paymentHash }
+}
+
+function createMockBackend(invoiceMap: Map<string, { preimage: string; paymentHash: string }>): LightningBackend {
+  return {
+    async createInvoice(amountSats: number, memo?: string) {
+      const { preimage, paymentHash } = makePreimage()
+      invoiceMap.set(paymentHash, { preimage, paymentHash })
+      return { bolt11: `lnbc${amountSats}test${paymentHash.slice(0, 16)}`, paymentHash }
+    },
+    async checkInvoice(paymentHash: string) {
+      const entry = invoiceMap.get(paymentHash)
+      return entry ? { paid: true, preimage: entry.preimage } : { paid: false }
+    },
+    async sendPayment(bolt11: string) {
+      return { preimage: randomBytes(32).toString('hex') }
+    },
+  }
+}
+
+function makeRequest(authHeader: string): TollBoothRequest {
+  return {
+    method: 'GET',
+    path: '/v1/chat/completions',
+    headers: { authorization: authHeader },
+    ip: '127.0.0.1',
+  }
+}
+
+function encodeCredential(credential: IETFCredential): string {
+  return `Payment ${Buffer.from(JSON.stringify(credential)).toString('base64url')}`
+}
+
+// --- Tests ---
+
+describe('IETF Session Rail', () => {
+  let storage: StorageBackend
+  let invoiceMap: Map<string, { preimage: string; paymentHash: string }>
+  let backend: LightningBackend
+  const sessionConfig: SessionConfig = {
+    maxSessionDurationMs: 60_000, // 1 minute for fast tests
+    maxDepositSats: 10_000,
+  }
+
+  beforeEach(() => {
+    storage = memoryStorage()
+    invoiceMap = new Map()
+    backend = createMockBackend(invoiceMap)
+  })
+
+  function createRail() {
+    return createIETFSessionRail({
+      hmacSecret: HMAC_SECRET,
+      realm: REALM,
+      backend,
+      storage,
+      session: sessionConfig,
+    })
+  }
+
+  describe('detect', () => {
+    it('detects session bearer auth', () => {
+      const rail = createRail()
+      const credential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: 'abc' },
+      }
+      const auth = encodeCredential(credential)
+      expect(rail.detect(makeRequest(auth))).toBe(true)
+    })
+
+    it('detects session open auth', () => {
+      const rail = createRail()
+      const credential: IETFCredential = {
+        challenge: { id: 'x', realm: REALM, method: 'lightning', intent: 'session', request: 'x' },
+        payload: { action: 'open', preimage: 'abc' },
+      }
+      const auth = encodeCredential(credential)
+      expect(rail.detect(makeRequest(auth))).toBe(true)
+    })
+
+    it('does not detect charge intent', () => {
+      const rail = createRail()
+      const credential: IETFCredential = {
+        challenge: { id: 'x', realm: REALM, method: 'lightning', intent: 'charge', request: 'x' },
+        payload: { preimage: 'abc' },
+      }
+      const auth = encodeCredential(credential)
+      expect(rail.detect(makeRequest(auth))).toBe(false)
+    })
+
+    it('does not detect L402', () => {
+      const rail = createRail()
+      expect(rail.detect(makeRequest('L402 mac:preimage'))).toBe(false)
+    })
+  })
+
+  describe('challenge', () => {
+    it('issues a session challenge with deposit invoice', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 1000 })
+
+      expect(fragment.headers['WWW-Authenticate']).toMatch(/^Payment /)
+      expect(fragment.headers['WWW-Authenticate']).toContain('intent="session"')
+      expect(fragment.headers['WWW-Authenticate']).toContain(`realm="${REALM}"`)
+      expect(fragment.body.ietf_session).toBeDefined()
+
+      const body = fragment.body.ietf_session as Record<string, unknown>
+      expect(body.intent).toBe('session')
+      expect(body.deposit_sats).toBe(1000)
+      expect(body.ttl_seconds).toBe(60)
+    })
+
+    it('caps deposit at maxDepositSats', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 50_000 })
+
+      const body = fragment.body.ietf_session as Record<string, unknown>
+      expect(body.deposit_sats).toBe(10_000) // Capped
+    })
+  })
+
+  describe('full lifecycle: open → bearer → close', () => {
+    async function openSession(rail: ReturnType<typeof createRail>) {
+      // Get a challenge to extract the session request
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+
+      // Parse challenge params from WWW-Authenticate header
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const realmMatch = wwwAuth.match(/realm="([^"]+)"/)!
+      const methodMatch = wwwAuth.match(/method="([^"]+)"/)!
+      const intentMatch = wwwAuth.match(/intent="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      // Decode request to get payment hash
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const paymentHash = sessionRequest.deposit.paymentHash
+      const entry = invoiceMap.get(paymentHash)!
+
+      // Build open credential
+      const credential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: realmMatch[1],
+          method: methodMatch[1],
+          intent: intentMatch[1],
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'open',
+          preimage: entry.preimage,
+          returnInvoice: 'lnbc1testreturn',
+        } satisfies SessionOpenPayload,
+      }
+
+      const auth = encodeCredential(credential)
+      const result = await rail.verify(makeRequest(auth))
+      return { result, paymentHash, sessionRequest }
+    }
+
+    it('opens a session with valid preimage', async () => {
+      const rail = createRail()
+      const { result } = await openSession(rail)
+
+      expect(result.authenticated).toBe(true)
+      expect(result.mode).toBe('credit')
+      expect(result.creditBalance).toBe(500)
+      expect(result.customCaveats?.['X-Session-Token']).toBeDefined()
+      expect(result.customCaveats?.['X-Session-Id']).toBeDefined()
+      expect(result.customCaveats?.['X-Session-Expires']).toBeDefined()
+    })
+
+    it('authenticates with bearer token', async () => {
+      const rail = createRail()
+      const { result } = await openSession(rail)
+      const bearerToken = result.customCaveats!['X-Session-Token']
+
+      // Use bearer token for a request
+      const bearerCredential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: bearerToken } satisfies SessionBearerPayload,
+      }
+      const bearerAuth = encodeCredential(bearerCredential)
+      const bearerResult = await rail.verify(makeRequest(bearerAuth))
+
+      expect(bearerResult.authenticated).toBe(true)
+      expect(bearerResult.mode).toBe('credit')
+      expect(bearerResult.creditBalance).toBe(500)
+    })
+
+    it('deducts balance via storage on bearer auth', async () => {
+      const rail = createRail()
+      const { result } = await openSession(rail)
+      const sessionId = result.customCaveats!['X-Session-Id']
+
+      // Simulate a deduction (normally done by TollBoothEngine)
+      storage.deductSession(sessionId, 100)
+
+      // Check balance via bearer
+      const bearerToken = result.customCaveats!['X-Session-Token']
+      const bearerCredential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: bearerToken } satisfies SessionBearerPayload,
+      }
+      const bearerResult = await rail.verify(makeRequest(encodeCredential(bearerCredential)))
+
+      expect(bearerResult.creditBalance).toBe(400)
+    })
+
+    it('closes session and triggers refund', async () => {
+      const rail = createRail()
+      const { result, sessionRequest } = await openSession(rail)
+      const bearerToken = result.customCaveats!['X-Session-Token']
+
+      // Get a new challenge for the close action (reuse params from open)
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const newSessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const newEntry = invoiceMap.get(newSessionRequest.deposit.paymentHash)!
+
+      const closeCredential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'close',
+          sessionToken: bearerToken,
+        } satisfies SessionClosePayload,
+      }
+
+      const closeResult = await rail.verify(makeRequest(encodeCredential(closeCredential)))
+
+      expect(closeResult.authenticated).toBe(true)
+      expect(closeResult.creditBalance).toBe(0)
+      expect(closeResult.customCaveats?.['X-Session-Closed']).toBe('true')
+    })
+
+    it('rejects bearer token after close', async () => {
+      const rail = createRail()
+      const { result, sessionRequest } = await openSession(rail)
+      const bearerToken = result.customCaveats!['X-Session-Token']
+      const sessionId = result.customCaveats!['X-Session-Id']
+
+      // Close via storage directly
+      storage.closeSession(sessionId)
+
+      const bearerCredential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: bearerToken } satisfies SessionBearerPayload,
+      }
+      const bearerResult = await rail.verify(makeRequest(encodeCredential(bearerCredential)))
+      expect(bearerResult.authenticated).toBe(false)
+    })
+  })
+
+  describe('compliance guardrails', () => {
+    it('rejects deposit exceeding maxDepositSats', async () => {
+      const rail = createRail()
+      // Open with the capped amount succeeds, but verify with a forged higher amount would fail
+      // because the HMAC binding prevents tampering
+      const { result } = await (async () => {
+        const fragment = await rail.challenge('/api/test', { sats: 10_000 })
+        const wwwAuth = fragment.headers['WWW-Authenticate']
+        const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+        const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+        const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+        const sessionRequest: SessionChallengeRequest = JSON.parse(
+          Buffer.from(requestMatch[1], 'base64url').toString()
+        )
+        const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+        const credential: IETFCredential = {
+          challenge: {
+            id: idMatch[1],
+            realm: REALM,
+            method: 'lightning',
+            intent: 'session',
+            request: requestMatch[1],
+            expires: expiresMatch[1],
+          },
+          payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+        }
+
+        return { result: await rail.verify(makeRequest(encodeCredential(credential))) }
+      })()
+
+      expect(result.authenticated).toBe(true)
+      expect(result.creditBalance).toBe(10_000) // At cap, not exceeding
+    })
+
+    it('rejects top-up that would exceed maxDepositSats', async () => {
+      const rail = createRail()
+
+      // Open a session at 8000 sats
+      const fragment = await rail.challenge('/api/test', { sats: 8000 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const openCredential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+      }
+
+      const openResult = await rail.verify(makeRequest(encodeCredential(openCredential)))
+      expect(openResult.authenticated).toBe(true)
+      const bearerToken = openResult.customCaveats!['X-Session-Token']
+
+      // Try to top up 5000 sats (would make 13000 > 10000 cap)
+      const topupFragment = await rail.challenge('/api/test', { sats: 5000 })
+      const topupWwwAuth = topupFragment.headers['WWW-Authenticate']
+      const topupIdMatch = topupWwwAuth.match(/id="([^"]+)"/)!
+      const topupRequestMatch = topupWwwAuth.match(/request="([^"]+)"/)!
+      const topupExpiresMatch = topupWwwAuth.match(/expires="([^"]+)"/)!
+
+      const topupSessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(topupRequestMatch[1], 'base64url').toString()
+      )
+      const topupEntry = invoiceMap.get(topupSessionRequest.deposit.paymentHash)!
+
+      const topupCredential: IETFCredential = {
+        challenge: {
+          id: topupIdMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: topupRequestMatch[1],
+          expires: topupExpiresMatch[1],
+        },
+        payload: {
+          action: 'topup',
+          sessionToken: bearerToken,
+          preimage: topupEntry.preimage,
+        } satisfies SessionTopUpPayload,
+      }
+
+      const topupResult = await rail.verify(makeRequest(encodeCredential(topupCredential)))
+      expect(topupResult.authenticated).toBe(false) // Exceeds cap
+    })
+
+    it('sweeps expired sessions', async () => {
+      const shortConfig: SessionConfig = {
+        maxSessionDurationMs: 1, // Expires immediately
+        maxDepositSats: 10_000,
+      }
+      const rail = createIETFSessionRail({
+        hmacSecret: HMAC_SECRET,
+        realm: REALM,
+        backend,
+        storage,
+        session: shortConfig,
+      })
+
+      // Open a session
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const credential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: {
+          action: 'open',
+          preimage: entry.preimage,
+          returnInvoice: 'lnbc1testreturn',
+        } satisfies SessionOpenPayload,
+      }
+
+      await rail.verify(makeRequest(encodeCredential(credential)))
+
+      // Wait for expiry
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Sweep
+      const swept = await rail.sweepExpired()
+      expect(swept).toBe(1)
+    })
+  })
+
+  describe('security', () => {
+    it('rejects invalid preimage', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const wrongPreimage = randomBytes(32).toString('hex')
+
+      const credential: IETFCredential = {
+        challenge: {
+          id: idMatch[1],
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: { action: 'open', preimage: wrongPreimage } satisfies SessionOpenPayload,
+      }
+
+      const result = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(result.authenticated).toBe(false)
+    })
+
+    it('rejects tampered challenge (HMAC failure)', async () => {
+      const rail = createRail()
+      const fragment = await rail.challenge('/api/test', { sats: 500 })
+      const wwwAuth = fragment.headers['WWW-Authenticate']
+      const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+      const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+      const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+      const sessionRequest: SessionChallengeRequest = JSON.parse(
+        Buffer.from(requestMatch[1], 'base64url').toString()
+      )
+      const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+      const credential: IETFCredential = {
+        challenge: {
+          id: 'tampered-id',
+          realm: REALM,
+          method: 'lightning',
+          intent: 'session',
+          request: requestMatch[1],
+          expires: expiresMatch[1],
+        },
+        payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+      }
+
+      const result = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(result.authenticated).toBe(false)
+    })
+
+    it('rejects unknown bearer token', async () => {
+      const rail = createRail()
+      const credential: IETFCredential = {
+        challenge: { id: '', realm: '', method: '', intent: '', request: '' },
+        payload: { action: 'bearer', sessionToken: 'nonexistent' } satisfies SessionBearerPayload,
+      }
+
+      const result = await rail.verify(makeRequest(encodeCredential(credential)))
+      expect(result.authenticated).toBe(false)
+    })
+
+    it('generates unique bearer tokens per session', async () => {
+      const rail = createRail()
+      const tokens: string[] = []
+
+      for (let i = 0; i < 5; i++) {
+        const fragment = await rail.challenge('/api/test', { sats: 100 })
+        const wwwAuth = fragment.headers['WWW-Authenticate']
+        const idMatch = wwwAuth.match(/id="([^"]+)"/)!
+        const requestMatch = wwwAuth.match(/request="([^"]+)"/)!
+        const expiresMatch = wwwAuth.match(/expires="([^"]+)"/)!
+
+        const sessionRequest: SessionChallengeRequest = JSON.parse(
+          Buffer.from(requestMatch[1], 'base64url').toString()
+        )
+        const entry = invoiceMap.get(sessionRequest.deposit.paymentHash)!
+
+        const credential: IETFCredential = {
+          challenge: {
+            id: idMatch[1],
+            realm: REALM,
+            method: 'lightning',
+            intent: 'session',
+            request: requestMatch[1],
+            expires: expiresMatch[1],
+          },
+          payload: { action: 'open', preimage: entry.preimage } satisfies SessionOpenPayload,
+        }
+
+        const result = await rail.verify(makeRequest(encodeCredential(credential)))
+        tokens.push(result.customCaveats!['X-Session-Token'])
+      }
+
+      const unique = new Set(tokens)
+      expect(unique.size).toBe(5)
+    })
+  })
+})

--- a/src/core/ietf-session.ts
+++ b/src/core/ietf-session.ts
@@ -472,7 +472,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
 
         // Check deposit cap
         const topupAmount = parseInt(sessionRequest.deposit.amount, 10)
-        if (session.balanceSats + topupAmount > maxDepositSats) {
+        if (session.depositSats + topupAmount > maxDepositSats) {
           return { authenticated: false, paymentId: session.sessionId, mode: 'credit', currency: 'sat' }
         }
 

--- a/src/core/ietf-session.ts
+++ b/src/core/ietf-session.ts
@@ -16,6 +16,32 @@ import {
 } from './ietf-payment.js'
 import type { IETFChallengeParams, IETFCredential } from './ietf-payment.js'
 
+// --- BOLT11 amount parsing ---
+
+/**
+ * Extract the amount in satoshis from a BOLT11 invoice.
+ * Returns undefined for amountless invoices.
+ * Only parses the human-readable prefix — no full BOLT11 decode needed.
+ */
+function parseBolt11AmountSats(bolt11: string): number | undefined {
+  // BOLT11 format: ln + network + amount + separator
+  // Amount is digits + optional multiplier: m=milli, u=micro, n=nano, p=pico
+  const match = bolt11.match(/^ln[a-z]*?(\d+)([munp]?)1/)
+  if (!match) return undefined
+  const num = parseInt(match[1], 10)
+  const multiplier = match[2]
+  // Base unit is BTC. Convert to satoshis (1 BTC = 100,000,000 sats)
+  const btcToSats = 100_000_000
+  switch (multiplier) {
+    case 'm': return Math.round(num * btcToSats / 1000)       // milli-BTC
+    case 'u': return Math.round(num * btcToSats / 1_000_000)  // micro-BTC
+    case 'n': return Math.round(num * btcToSats / 1_000_000_000) // nano-BTC
+    case 'p': return Math.round(num * btcToSats / 1_000_000_000_000) // pico-BTC
+    case '':  return Math.round(num * btcToSats)               // full BTC
+    default:  return undefined
+  }
+}
+
 // --- Session-specific types ---
 
 /** Session challenge request (embedded in challenge `request` param). */
@@ -116,6 +142,9 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
   getSessionByBearer(token: string): Session | null
 } {
   const { hmacSecret, realm, backend, storage, description } = config
+  if (!backend.sendPayment) {
+    throw new Error('Session intent requires a Lightning backend that supports sendPayment() for refunds')
+  }
   const label = config.serviceName ?? 'toll-booth'
   const maxDurationMs = config.session.maxSessionDurationMs ?? DEFAULT_MAX_DURATION_MS
   const maxDepositSats = config.session.maxDepositSats ?? DEFAULT_MAX_DEPOSIT_SATS
@@ -133,9 +162,16 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
       try {
         await refundAndClose(session)
         count++
-      } catch {
-        // Log failure but continue sweeping other sessions.
-        // Session remains open for next sweep attempt.
+      } catch (err) {
+        // Emit event so operators can observe stuck sessions
+        emitEvent({
+          type: 'expire',
+          sessionId: session.sessionId,
+          paymentHash: session.paymentHash,
+          amountSats: session.balanceSats,
+          balanceSats: session.balanceSats,
+          timestamp: new Date().toISOString(),
+        })
       }
     }
     // Also prune long-closed sessions
@@ -143,17 +179,38 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
     return count
   }
 
-  /** Refund remaining balance and close a session. */
+  /**
+   * Refund remaining balance and close a session.
+   * Uses atomic close-before-pay to prevent TOCTOU double-refund:
+   * the session is marked closed BEFORE the payment is sent.
+   */
   async function refundAndClose(session: Session): Promise<string | undefined> {
+    // TOCTOU protection: close the session first, then attempt refund.
+    // This prevents concurrent close + sweep from both sending payments.
+    storage.closeSession(session.sessionId)
+
     let refundPreimage: string | undefined
-    if (session.balanceSats > 0 && session.returnInvoice) {
-      if (!backend.sendPayment) {
-        throw new Error('Lightning backend does not support sendPayment — cannot refund session')
+    if (session.balanceSats > 0 && session.returnInvoice && backend.sendPayment) {
+      // Validate return invoice amount matches remaining balance
+      const invoiceAmountSats = parseBolt11AmountSats(session.returnInvoice)
+      if (invoiceAmountSats !== undefined && invoiceAmountSats !== session.balanceSats) {
+        // Amount mismatch — do not pay. Session is already closed.
+        emitEvent({
+          type: 'expire',
+          sessionId: session.sessionId,
+          paymentHash: session.paymentHash,
+          amountSats: session.balanceSats,
+          balanceSats: 0,
+          timestamp: new Date().toISOString(),
+        })
+        return undefined
       }
       const result = await backend.sendPayment(session.returnInvoice)
       refundPreimage = result.preimage
+      // Update the closed session with the refund preimage
+      storage.closeSession(session.sessionId, refundPreimage)
     }
-    storage.closeSession(session.sessionId, refundPreimage)
+
     emitEvent({
       type: session.balanceSats > 0 ? 'close' : 'expire',
       sessionId: session.sessionId,
@@ -351,8 +408,13 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
           return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
         }
 
-        // Create session
+        // Create session — reject replay of same deposit
         const sessionId = paymentHash // Deterministic: one session per deposit
+        const existing = storage.getSession(sessionId)
+        if (existing) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
         const bearerToken = randomBytes(32).toString('hex')
         const expiresAt = new Date(Date.now() + maxDurationMs).toISOString()
 
@@ -445,12 +507,40 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
           return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
         }
 
-        // Use return invoice from close request or from session open
-        const returnInvoice = close.returnInvoice ?? session.returnInvoice
+        // Refund-to-originator: always use the return invoice from session open.
+        // Close-time override is not permitted (prevents refund redirect attacks).
+        const returnInvoice = session.returnInvoice
 
         // Attempt refund if balance > 0 and return invoice exists
         let refundPreimage: string | undefined
         if (session.balanceSats > 0 && returnInvoice && backend.sendPayment) {
+          // CRITICAL: validate return invoice amount matches remaining balance.
+          // Amountless invoices are always safe; amount-specified invoices must
+          // match the remaining balance to prevent operator fund drain.
+          const invoiceAmountSats = parseBolt11AmountSats(returnInvoice)
+          if (invoiceAmountSats !== undefined && invoiceAmountSats !== session.balanceSats) {
+            // Amount mismatch — do not pay. Emit event for operator visibility.
+            emitEvent({
+              type: 'close',
+              sessionId: session.sessionId,
+              paymentHash: session.paymentHash,
+              amountSats: session.balanceSats,
+              balanceSats: 0,
+              timestamp: new Date().toISOString(),
+            })
+            storage.closeSession(session.sessionId)
+            return {
+              authenticated: true,
+              paymentId: session.sessionId,
+              mode: 'credit',
+              creditBalance: 0,
+              currency: 'sat',
+              customCaveats: {
+                'X-Session-Closed': 'true',
+                'X-Refund-Status': 'amount-mismatch',
+              },
+            }
+          }
           try {
             const result = await backend.sendPayment(returnInvoice)
             refundPreimage = result.preimage

--- a/src/core/ietf-session.ts
+++ b/src/core/ietf-session.ts
@@ -1,0 +1,501 @@
+// src/core/ietf-session.ts
+//
+// IETF Payment session intent (deposit/bearer/top-up/close lifecycle).
+// Implements the session intent from forgesworn/payment-methods alongside
+// the existing charge intent in ietf-payment.ts.
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import type { StorageBackend, Session } from '../storage/interface.js'
+import type { LightningBackend, SessionConfig } from '../types.js'
+import type { PaymentRail, PriceInfo, ChallengeFragment, RailVerifyResult } from './payment-rail.js'
+import type { TollBoothRequest } from './types.js'
+import {
+  computeChallengeId,
+  verifyChallengeId,
+  encodeJCS,
+} from './ietf-payment.js'
+import type { IETFChallengeParams, IETFCredential } from './ietf-payment.js'
+
+// --- Session-specific types ---
+
+/** Session challenge request (embedded in challenge `request` param). */
+export interface SessionChallengeRequest {
+  method: string
+  intent: string
+  action: string
+  deposit: {
+    amount: string
+    currency: string
+    invoice: string
+    paymentHash: string
+    network: string
+  }
+  ttl: number
+  returnInvoiceRequired: boolean
+}
+
+/** Session open payload (in credential `payload`). */
+export interface SessionOpenPayload {
+  action: 'open'
+  preimage: string
+  returnInvoice?: string
+}
+
+/** Session bearer payload (in credential `payload`). */
+export interface SessionBearerPayload {
+  action: 'bearer'
+  sessionToken: string
+}
+
+/** Session top-up payload (in credential `payload`). */
+export interface SessionTopUpPayload {
+  action: 'topup'
+  sessionToken: string
+  preimage: string
+}
+
+/** Session close payload (in credential `payload`). */
+export interface SessionClosePayload {
+  action: 'close'
+  sessionToken: string
+  returnInvoice?: string
+}
+
+type SessionPayload =
+  | SessionOpenPayload
+  | SessionBearerPayload
+  | SessionTopUpPayload
+  | SessionClosePayload
+
+// --- Session rail config ---
+
+export interface IETFSessionRailConfig {
+  /** 64-char hex secret for HMAC challenge binding (same as charge rail). */
+  hmacSecret: string
+  /** Protection space (e.g. 'api.example.com'). */
+  realm: string
+  /** Lightning backend for invoice creation and refund payments. */
+  backend: LightningBackend
+  /** Storage backend for session persistence. */
+  storage: StorageBackend
+  /** Session configuration with compliance guardrails. */
+  session: SessionConfig
+  /** Human-readable service description for challenges. */
+  description?: string
+  /** Human-readable service name for invoice memos. */
+  serviceName?: string
+  /** Callback fired on session events (open, close, expire). */
+  onSessionEvent?: (event: SessionEvent) => void
+}
+
+export interface SessionEvent {
+  type: 'open' | 'close' | 'expire' | 'topup' | 'deduct'
+  sessionId: string
+  paymentHash: string
+  amountSats?: number
+  balanceSats?: number
+  refundPreimage?: string
+  timestamp: string
+}
+
+// --- Defaults ---
+
+const DEFAULT_MAX_DURATION_MS = 86_400_000    // 24 hours
+const DEFAULT_MAX_DEPOSIT_SATS = 100_000      // ~$30 USD
+const DEFAULT_PRUNE_INTERVAL_MS = 3_600_000   // 1 hour
+const DEFAULT_CHALLENGE_EXPIRY_SECS = 900     // 15 minutes
+
+// --- Session rail factory ---
+
+export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRail & {
+  /** Start the auto-close sweep for expired sessions. Returns a stop function. */
+  startSweep(): () => void
+  /** Manually sweep expired sessions (useful for testing). */
+  sweepExpired(): Promise<number>
+  /** Get a session by bearer token (for NeedTopUp checks in streaming). */
+  getSessionByBearer(token: string): Session | null
+} {
+  const { hmacSecret, realm, backend, storage, description } = config
+  const label = config.serviceName ?? 'toll-booth'
+  const maxDurationMs = config.session.maxSessionDurationMs ?? DEFAULT_MAX_DURATION_MS
+  const maxDepositSats = config.session.maxDepositSats ?? DEFAULT_MAX_DEPOSIT_SATS
+  const pruneIntervalMs = config.session.sessionPruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS
+
+  function emitEvent(event: SessionEvent) {
+    config.onSessionEvent?.(event)
+  }
+
+  /** Sweep expired sessions: auto-close and attempt refund. */
+  async function sweepExpired(): Promise<number> {
+    const expired = storage.getExpiredSessions()
+    let count = 0
+    for (const session of expired) {
+      try {
+        await refundAndClose(session)
+        count++
+      } catch {
+        // Log failure but continue sweeping other sessions.
+        // Session remains open for next sweep attempt.
+      }
+    }
+    // Also prune long-closed sessions
+    storage.pruneClosedSessions(maxDurationMs)
+    return count
+  }
+
+  /** Refund remaining balance and close a session. */
+  async function refundAndClose(session: Session): Promise<string | undefined> {
+    let refundPreimage: string | undefined
+    if (session.balanceSats > 0 && session.returnInvoice) {
+      if (!backend.sendPayment) {
+        throw new Error('Lightning backend does not support sendPayment — cannot refund session')
+      }
+      const result = await backend.sendPayment(session.returnInvoice)
+      refundPreimage = result.preimage
+    }
+    storage.closeSession(session.sessionId, refundPreimage)
+    emitEvent({
+      type: session.balanceSats > 0 ? 'close' : 'expire',
+      sessionId: session.sessionId,
+      paymentHash: session.paymentHash,
+      amountSats: session.balanceSats,
+      balanceSats: 0,
+      refundPreimage,
+      timestamp: new Date().toISOString(),
+    })
+    return refundPreimage
+  }
+
+  return {
+    type: 'ietf-session',
+    creditSupported: true,
+
+    canChallenge(price: PriceInfo): boolean {
+      return price.sats !== undefined
+    },
+
+    detect(req: TollBoothRequest): boolean {
+      const auth = req.headers.authorization ?? req.headers.Authorization ?? ''
+      if (!/^Payment\s/i.test(auth)) return false
+      // Distinguish session from charge: check if payload has session action
+      const token = auth.replace(/^Payment\s+/i, '')
+      try {
+        const decoded = JSON.parse(Buffer.from(token, 'base64url').toString())
+        const action = decoded?.payload?.action
+        return action === 'bearer' || action === 'open' || action === 'topup' || action === 'close'
+      } catch {
+        return false
+      }
+    },
+
+    async challenge(route: string, price: PriceInfo): Promise<ChallengeFragment> {
+      const depositSats = Math.min(price.sats!, maxDepositSats)
+      const invoice = await backend.createInvoice(depositSats, `${label}: session deposit for ${route}`)
+
+      const ttlSecs = Math.floor(maxDurationMs / 1000)
+      const sessionRequest: SessionChallengeRequest = {
+        method: 'lightning',
+        intent: 'session',
+        action: 'challenge',
+        deposit: {
+          amount: String(depositSats),
+          currency: 'sat',
+          invoice: invoice.bolt11,
+          paymentHash: invoice.paymentHash,
+          network: 'mainnet',
+        },
+        ttl: ttlSecs,
+        returnInvoiceRequired: true,
+      }
+
+      const requestEncoded = encodeJCS(sessionRequest as unknown as Record<string, unknown>)
+      const expires = new Date(Date.now() + DEFAULT_CHALLENGE_EXPIRY_SECS * 1000).toISOString()
+
+      const challengeParams: IETFChallengeParams = {
+        realm,
+        method: 'lightning',
+        intent: 'session',
+        request: requestEncoded,
+        expires,
+        ...(description && { description }),
+      }
+
+      const id = computeChallengeId(hmacSecret, challengeParams)
+
+      const parts = [
+        `id="${id}"`,
+        `realm="${realm}"`,
+        `method="lightning"`,
+        `intent="session"`,
+        `request="${requestEncoded}"`,
+        `expires="${expires}"`,
+      ]
+      if (description) parts.push(`description="${description}"`)
+
+      return {
+        headers: {
+          'WWW-Authenticate': `Payment ${parts.join(', ')}`,
+        },
+        body: {
+          ietf_session: {
+            scheme: 'Payment',
+            description: 'Deposit-based session (IETF standard, streaming)',
+            method: 'lightning',
+            intent: 'session',
+            payment_hash: invoice.paymentHash,
+            deposit_sats: depositSats,
+            ttl_seconds: ttlSecs,
+          },
+        },
+      }
+    },
+
+    async verify(req: TollBoothRequest): Promise<RailVerifyResult> {
+      const auth = req.headers.authorization ?? req.headers.Authorization ?? ''
+      const token = auth.replace(/^Payment\s+/i, '')
+
+      let credential: IETFCredential
+      try {
+        credential = JSON.parse(Buffer.from(token, 'base64url').toString())
+      } catch {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      const payload = credential.payload as unknown as SessionPayload
+      if (!payload?.action) {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      // --- Bearer auth (most common — used on every request) ---
+      if (payload.action === 'bearer') {
+        const bearer = payload as SessionBearerPayload
+        if (!bearer.sessionToken) {
+          return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+        }
+        const session = storage.getSessionByBearer(bearer.sessionToken)
+        if (!session || session.closedAt) {
+          return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+        }
+        // Check session not expired
+        if (new Date(session.expiresAt).getTime() < Date.now()) {
+          return { authenticated: false, paymentId: session.paymentHash, mode: 'credit', currency: 'sat' }
+        }
+        return {
+          authenticated: true,
+          paymentId: session.sessionId,
+          mode: 'credit',
+          creditBalance: session.balanceSats,
+          currency: 'sat',
+        }
+      }
+
+      // --- Open, top-up, close require challenge verification ---
+      const challenge = credential.challenge
+      if (!challenge?.id || !challenge.realm || !challenge.method || !challenge.intent || !challenge.request) {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      // Verify HMAC binding
+      const params: IETFChallengeParams = {
+        realm: challenge.realm,
+        method: challenge.method,
+        intent: challenge.intent,
+        request: challenge.request,
+        expires: challenge.expires,
+        digest: challenge.digest,
+        description: challenge.description,
+        opaque: challenge.opaque,
+      }
+      if (!verifyChallengeId(hmacSecret, challenge.id, params)) {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      // Check challenge expiry
+      if (challenge.expires) {
+        const expiresAt = new Date(challenge.expires).getTime()
+        if (isNaN(expiresAt) || Date.now() > expiresAt) {
+          return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+        }
+      }
+
+      // Decode session request
+      let sessionRequest: SessionChallengeRequest
+      try {
+        sessionRequest = JSON.parse(Buffer.from(challenge.request, 'base64url').toString())
+      } catch {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      const paymentHash = sessionRequest.deposit?.paymentHash
+      if (!paymentHash || !/^[0-9a-f]{64}$/i.test(paymentHash)) {
+        return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      }
+
+      // --- Open: verify deposit preimage, create session ---
+      if (payload.action === 'open') {
+        const open = payload as SessionOpenPayload
+        if (!open.preimage || !/^[0-9a-f]{64}$/i.test(open.preimage)) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Verify preimage
+        const computed = createHash('sha256').update(Buffer.from(open.preimage, 'hex')).digest()
+        const expected = Buffer.from(paymentHash, 'hex')
+        if (!timingSafeEqual(computed, expected)) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Check deposit limit
+        const depositSats = parseInt(sessionRequest.deposit.amount, 10)
+        if (depositSats > maxDepositSats) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Create session
+        const sessionId = paymentHash // Deterministic: one session per deposit
+        const bearerToken = randomBytes(32).toString('hex')
+        const expiresAt = new Date(Date.now() + maxDurationMs).toISOString()
+
+        storage.createSession({
+          sessionId,
+          paymentHash,
+          balanceSats: depositSats,
+          depositSats,
+          bearerToken,
+          expiresAt,
+          returnInvoice: open.returnInvoice,
+        })
+
+        emitEvent({
+          type: 'open',
+          sessionId,
+          paymentHash,
+          amountSats: depositSats,
+          balanceSats: depositSats,
+          timestamp: new Date().toISOString(),
+        })
+
+        return {
+          authenticated: true,
+          paymentId: sessionId,
+          mode: 'credit',
+          creditBalance: depositSats,
+          currency: 'sat',
+          customCaveats: {
+            'X-Session-Token': bearerToken,
+            'X-Session-Expires': expiresAt,
+            'X-Session-Id': sessionId,
+          },
+        }
+      }
+
+      // --- Top-up and close require an existing session ---
+      if (payload.action === 'topup') {
+        const topup = payload as SessionTopUpPayload
+        if (!topup.sessionToken || !topup.preimage) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        const session = storage.getSessionByBearer(topup.sessionToken)
+        if (!session || session.closedAt) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Verify top-up preimage
+        const computed = createHash('sha256').update(Buffer.from(topup.preimage, 'hex')).digest()
+        const expected = Buffer.from(paymentHash, 'hex')
+        if (!timingSafeEqual(computed, expected)) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Check deposit cap
+        const topupAmount = parseInt(sessionRequest.deposit.amount, 10)
+        if (session.balanceSats + topupAmount > maxDepositSats) {
+          return { authenticated: false, paymentId: session.sessionId, mode: 'credit', currency: 'sat' }
+        }
+
+        const { newBalance } = storage.topUpSession(session.sessionId, topupAmount)
+
+        emitEvent({
+          type: 'topup',
+          sessionId: session.sessionId,
+          paymentHash: session.paymentHash,
+          amountSats: topupAmount,
+          balanceSats: newBalance,
+          timestamp: new Date().toISOString(),
+        })
+
+        return {
+          authenticated: true,
+          paymentId: session.sessionId,
+          mode: 'credit',
+          creditBalance: newBalance,
+          currency: 'sat',
+        }
+      }
+
+      if (payload.action === 'close') {
+        const close = payload as SessionClosePayload
+        if (!close.sessionToken) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        const session = storage.getSessionByBearer(close.sessionToken)
+        if (!session || session.closedAt) {
+          return { authenticated: false, paymentId: paymentHash, mode: 'credit', currency: 'sat' }
+        }
+
+        // Use return invoice from close request or from session open
+        const returnInvoice = close.returnInvoice ?? session.returnInvoice
+
+        // Attempt refund if balance > 0 and return invoice exists
+        let refundPreimage: string | undefined
+        if (session.balanceSats > 0 && returnInvoice && backend.sendPayment) {
+          try {
+            const result = await backend.sendPayment(returnInvoice)
+            refundPreimage = result.preimage
+          } catch {
+            // Refund failed — close anyway, operator can handle manually
+          }
+        }
+
+        storage.closeSession(session.sessionId, refundPreimage)
+
+        emitEvent({
+          type: 'close',
+          sessionId: session.sessionId,
+          paymentHash: session.paymentHash,
+          amountSats: session.balanceSats,
+          balanceSats: 0,
+          refundPreimage,
+          timestamp: new Date().toISOString(),
+        })
+
+        return {
+          authenticated: true,
+          paymentId: session.sessionId,
+          mode: 'credit',
+          creditBalance: 0,
+          currency: 'sat',
+          customCaveats: {
+            'X-Session-Closed': 'true',
+            ...(refundPreimage && { 'X-Refund-Preimage': refundPreimage }),
+          },
+        }
+      }
+
+      return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+    },
+
+    startSweep(): () => void {
+      const timer = setInterval(() => { sweepExpired().catch(() => {}) }, pruneIntervalMs)
+      return () => clearInterval(timer)
+    },
+
+    sweepExpired,
+
+    getSessionByBearer(token: string): Session | null {
+      return storage.getSessionByBearer(token)
+    },
+  }
+}

--- a/src/core/ietf-session.ts
+++ b/src/core/ietf-session.ts
@@ -340,7 +340,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
         return {
           authenticated: true,
           paymentId: session.sessionId,
-          mode: 'credit',
+          mode: 'session',
           creditBalance: session.balanceSats,
           currency: 'sat',
         }
@@ -440,7 +440,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
         return {
           authenticated: true,
           paymentId: sessionId,
-          mode: 'credit',
+          mode: 'session',
           creditBalance: depositSats,
           currency: 'sat',
           customCaveats: {
@@ -490,7 +490,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
         return {
           authenticated: true,
           paymentId: session.sessionId,
-          mode: 'credit',
+          mode: 'session',
           creditBalance: newBalance,
           currency: 'sat',
         }
@@ -532,7 +532,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
             return {
               authenticated: true,
               paymentId: session.sessionId,
-              mode: 'credit',
+              mode: 'session',
               creditBalance: 0,
               currency: 'sat',
               customCaveats: {
@@ -564,7 +564,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
         return {
           authenticated: true,
           paymentId: session.sessionId,
-          mode: 'credit',
+          mode: 'session',
           creditBalance: 0,
           currency: 'sat',
           customCaveats: {
@@ -574,7 +574,7 @@ export function createIETFSessionRail(config: IETFSessionRailConfig): PaymentRai
         }
       }
 
-      return { authenticated: false, paymentId: '', mode: 'credit', currency: 'sat' }
+      return { authenticated: false, paymentId: '', mode: 'session', currency: 'sat' }
     },
 
     startSweep(): () => void {

--- a/src/core/payment-rail.ts
+++ b/src/core/payment-rail.ts
@@ -53,7 +53,7 @@ export interface ChallengeFragment {
 export interface RailVerifyResult {
   authenticated: boolean
   paymentId: string
-  mode: 'per-request' | 'credit'
+  mode: 'per-request' | 'credit' | 'session'
   creditBalance?: number
   currency: Currency
   customCaveats?: Record<string, string>

--- a/src/core/toll-booth.ts
+++ b/src/core/toll-booth.ts
@@ -159,6 +159,9 @@ export function createTollBooth(config: TollBoothCoreConfig): TollBoothEngine {
           if (activeTypes.includes('xcashu')) {
             hints.push('Cashu: Send token via \u2014 X-Cashu header')
           }
+          if (activeTypes.includes('ietf-session')) {
+            hints.push('IETF Session: Deposit for streaming \u2014 Authorization: Payment <base64url session credential>')
+          }
           challengeBody.auth_hint = hints.length === 1 ? hints[0] : hints
         }
 
@@ -249,9 +252,23 @@ export function createTollBooth(config: TollBoothCoreConfig): TollBoothEngine {
               }
             }
 
-            const remaining = result.mode === 'credit'
-              ? storage.balance(result.paymentId, result.currency)
-              : undefined
+            // Session mode: deduct from session balance (not credits table)
+            let sessionBalance: number | undefined
+            if (result.mode === 'session' && result.paymentId && cost > 0) {
+              try {
+                const { newBalance } = storage.deductSession(result.paymentId, cost)
+                sessionBalance = newBalance
+              } catch {
+                // Insufficient session balance — fall through to challenge
+                break
+              }
+            }
+
+            const remaining = result.mode === 'session'
+              ? (sessionBalance ?? result.creditBalance)
+              : result.mode === 'credit'
+                ? storage.balance(result.paymentId, result.currency)
+                : undefined
 
             // Fire onPayment exactly once per paymentHash (first time seen)
             if (result.paymentId && !estimatedCosts.has(result.paymentId)) {
@@ -310,6 +327,14 @@ export function createTollBooth(config: TollBoothCoreConfig): TollBoothEngine {
                 reference: result.paymentId,
               })
               headers['Cache-Control'] = 'private'
+            }
+
+            // Session auth: add session-specific headers
+            if (result.mode === 'session') {
+              if (remaining !== undefined) {
+                headers['X-Session-Balance'] = String(remaining)
+              }
+              headers['Cache-Control'] = 'private, no-store'
             }
 
             config.onRequest?.({

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,11 @@ export { meltToLightning } from './core/melt-to-lightning.js'
 export type { MeltResult } from './core/melt-to-lightning.js'
 export { createIETFPaymentRail, computeChallengeId, verifyChallengeId, buildReceiptHeader, encodeJCS } from './core/ietf-payment.js'
 export type { IETFPaymentRailConfig, IETFChallengeParams, IETFCredential, IETFReceipt, LightningChargeRequest, LightningChargePayload, ReceiptOptions } from './core/ietf-payment.js'
-export type { IETFPaymentConfig } from './types.js'
+export type { IETFPaymentConfig, SessionConfig } from './types.js'
+
+// IETF Payment — session intent
+export { createIETFSessionRail } from './core/ietf-session.js'
+export type { IETFSessionRailConfig, SessionEvent, SessionChallengeRequest, SessionOpenPayload, SessionBearerPayload, SessionTopUpPayload, SessionClosePayload } from './core/ietf-session.js'
 
 // Utilities
 export { mintMacaroon, verifyMacaroon, parseCaveats } from './macaroon.js'

--- a/src/storage/interface.ts
+++ b/src/storage/interface.ts
@@ -20,6 +20,19 @@ export interface PendingClaim {
   claimedAt: string
 }
 
+export interface Session {
+  sessionId: string
+  paymentHash: string
+  balanceSats: number
+  depositSats: number
+  returnInvoice: string | null
+  bearerToken: string
+  createdAt: string
+  expiresAt: string
+  closedAt: string | null
+  refundPreimage: string | null
+}
+
 export interface StorageBackend {
   credit(paymentHash: string, amount: number, currency?: Currency): void
   debit(paymentHash: string, amount: number, currency?: Currency): DebitResult
@@ -63,5 +76,13 @@ export interface StorageBackend {
   pruneExpiredInvoices(maxAgeMs: number): number
   /** Delete zero-balance credits and aged settlements/claims. Returns total deleted rows. */
   pruneStaleRecords(maxAgeMs: number): number
+  createSession(session: { sessionId: string, paymentHash: string, balanceSats: number, depositSats: number, bearerToken: string, expiresAt: string, returnInvoice?: string }): void
+  getSession(sessionId: string): Session | null
+  getSessionByBearer(bearerToken: string): Session | null
+  deductSession(sessionId: string, amount: number): { newBalance: number }
+  topUpSession(sessionId: string, amount: number): { newBalance: number }
+  closeSession(sessionId: string, refundPreimage?: string): void
+  getExpiredSessions(): Session[]
+  pruneClosedSessions(maxAgeMs: number): number
   close(): void
 }

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -215,8 +215,12 @@ export function memoryStorage(): StorageBackend {
     },
 
     getSessionByBearer(bearerToken: string): Session | null {
+      const providedBuf = Buffer.from(bearerToken)
       for (const session of sessions.values()) {
-        if (session.bearerToken === bearerToken) return session
+        const storedBuf = Buffer.from(session.bearerToken)
+        if (storedBuf.length === providedBuf.length && timingSafeEqual(storedBuf, providedBuf)) {
+          return session
+        }
       }
       return null
     },
@@ -233,6 +237,7 @@ export function memoryStorage(): StorageBackend {
       const session = sessions.get(sessionId)
       if (!session || session.closedAt !== null) throw new Error(`Session not found or closed: ${sessionId}`)
       session.balanceSats += amount
+      session.depositSats += amount
       return { newBalance: session.balanceSats }
     },
 

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -1,7 +1,7 @@
 // src/storage/memory.ts
 import { timingSafeEqual } from 'node:crypto'
 import type { Currency } from '../core/payment-rail.js'
-import type { StorageBackend, DebitResult, StoredInvoice, PendingClaim } from './interface.js'
+import type { StorageBackend, DebitResult, StoredInvoice, PendingClaim, Session } from './interface.js'
 
 const DEFAULT_LEASE_MS = 30_000
 type StoredInvoiceRecord = StoredInvoice & { statusToken: string }
@@ -34,6 +34,7 @@ export function memoryStorage(): StorageBackend {
   const invoiceIps = new Map<string, string>()
   const settled = new Map<string, string | undefined>()
   const claims = new Map<string, { token: string; claimedAt: string; leaseExpiresAt: number }>()
+  const sessions = new Map<string, Session>()
 
   return {
     credit(paymentHash: string, amount: number, currency: Currency = 'sat'): void {
@@ -194,12 +195,85 @@ export function memoryStorage(): StorageBackend {
       return pruned
     },
 
+    createSession(session: { sessionId: string, paymentHash: string, balanceSats: number, depositSats: number, bearerToken: string, expiresAt: string, returnInvoice?: string }): void {
+      sessions.set(session.sessionId, {
+        sessionId: session.sessionId,
+        paymentHash: session.paymentHash,
+        balanceSats: session.balanceSats,
+        depositSats: session.depositSats,
+        returnInvoice: session.returnInvoice ?? null,
+        bearerToken: session.bearerToken,
+        createdAt: new Date().toISOString(),
+        expiresAt: session.expiresAt,
+        closedAt: null,
+        refundPreimage: null,
+      })
+    },
+
+    getSession(sessionId: string): Session | null {
+      return sessions.get(sessionId) ?? null
+    },
+
+    getSessionByBearer(bearerToken: string): Session | null {
+      for (const session of sessions.values()) {
+        if (session.bearerToken === bearerToken) return session
+      }
+      return null
+    },
+
+    deductSession(sessionId: string, amount: number): { newBalance: number } {
+      const session = sessions.get(sessionId)
+      if (!session || session.closedAt !== null) throw new Error(`Session not found or closed: ${sessionId}`)
+      if (session.balanceSats < amount) throw new Error(`Insufficient session balance: ${session.balanceSats} < ${amount}`)
+      session.balanceSats -= amount
+      return { newBalance: session.balanceSats }
+    },
+
+    topUpSession(sessionId: string, amount: number): { newBalance: number } {
+      const session = sessions.get(sessionId)
+      if (!session || session.closedAt !== null) throw new Error(`Session not found or closed: ${sessionId}`)
+      session.balanceSats += amount
+      return { newBalance: session.balanceSats }
+    },
+
+    closeSession(sessionId: string, refundPreimage?: string): void {
+      const session = sessions.get(sessionId)
+      if (session && session.closedAt === null) {
+        session.closedAt = new Date().toISOString()
+        session.refundPreimage = refundPreimage ?? null
+      }
+    },
+
+    getExpiredSessions(): Session[] {
+      const now = new Date().toISOString()
+      const result: Session[] = []
+      for (const session of sessions.values()) {
+        if (session.closedAt === null && session.expiresAt < now) {
+          result.push(session)
+        }
+      }
+      return result
+    },
+
+    pruneClosedSessions(maxAgeMs: number): number {
+      const cutoff = new Date(Date.now() - maxAgeMs).toISOString()
+      let pruned = 0
+      for (const [id, session] of sessions) {
+        if (session.closedAt !== null && session.closedAt < cutoff) {
+          sessions.delete(id)
+          pruned++
+        }
+      }
+      return pruned
+    },
+
     close(): void {
       balances.clear()
       invoices.clear()
       invoiceIps.clear()
       settled.clear()
       claims.clear()
+      sessions.clear()
     },
   }
 }

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -338,7 +338,7 @@ export function sqliteStorage(config?: SqliteStorageConfig): StorageBackend {
   )
 
   const stmtTopUpSession = db.prepare(
-    'UPDATE sessions SET balance_sats = balance_sats + ? WHERE session_id = ? AND closed_at IS NULL'
+    'UPDATE sessions SET balance_sats = balance_sats + ?, deposit_sats = deposit_sats + ? WHERE session_id = ? AND closed_at IS NULL'
   )
 
   const stmtCloseSession = db.prepare(
@@ -383,7 +383,7 @@ export function sqliteStorage(config?: SqliteStorageConfig): StorageBackend {
   const txnTopUpSession = db.transaction((sessionId: string, amount: number): { newBalance: number } => {
     const row = stmtGetSessionBalance.get(sessionId) as { balance_sats: number } | undefined
     if (!row) throw new Error(`Session not found or closed: ${sessionId}`)
-    stmtTopUpSession.run(amount, sessionId)
+    stmtTopUpSession.run(amount, amount, sessionId)
     return { newBalance: row.balance_sats + amount }
   })
 

--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -2,7 +2,7 @@
 import { timingSafeEqual } from 'node:crypto'
 import Database from 'better-sqlite3'
 import type { Currency } from '../core/payment-rail.js'
-import type { StorageBackend, DebitResult, StoredInvoice, PendingClaim } from './interface.js'
+import type { StorageBackend, DebitResult, StoredInvoice, PendingClaim, Session } from './interface.js'
 
 const DEFAULT_LEASE_MS = 30_000
 
@@ -99,6 +99,23 @@ export function sqliteStorage(config?: SqliteStorageConfig): StorageBackend {
   }
   // Copy legacy balance into balance_sats for existing rows.
   db.exec('UPDATE credits SET balance_sats = balance WHERE balance > 0 AND balance_sats = 0')
+
+  // Migration: add sessions table.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      payment_hash TEXT NOT NULL,
+      balance_sats INTEGER NOT NULL DEFAULT 0,
+      deposit_sats INTEGER NOT NULL DEFAULT 0,
+      return_invoice TEXT,
+      bearer_token TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      expires_at TEXT NOT NULL,
+      closed_at TEXT,
+      refund_preimage TEXT
+    )
+  `)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_bearer ON sessions(bearer_token)')
 
   // Per-currency prepared statements for credit operations
   const stmtCreditSat = db.prepare(`
@@ -302,6 +319,74 @@ export function sqliteStorage(config?: SqliteStorageConfig): StorageBackend {
     return updated.balance
   })
 
+  // Session prepared statements
+  const stmtCreateSession = db.prepare(`
+    INSERT INTO sessions (session_id, payment_hash, balance_sats, deposit_sats, bearer_token, expires_at, return_invoice)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  const stmtGetSession = db.prepare(
+    'SELECT session_id, payment_hash, balance_sats, deposit_sats, return_invoice, bearer_token, created_at, expires_at, closed_at, refund_preimage FROM sessions WHERE session_id = ?'
+  )
+
+  const stmtGetSessionByBearer = db.prepare(
+    'SELECT session_id, payment_hash, balance_sats, deposit_sats, return_invoice, bearer_token, created_at, expires_at, closed_at, refund_preimage FROM sessions WHERE bearer_token = ?'
+  )
+
+  const stmtDeductSession = db.prepare(
+    'UPDATE sessions SET balance_sats = balance_sats - ? WHERE session_id = ? AND balance_sats >= ? AND closed_at IS NULL'
+  )
+
+  const stmtTopUpSession = db.prepare(
+    'UPDATE sessions SET balance_sats = balance_sats + ? WHERE session_id = ? AND closed_at IS NULL'
+  )
+
+  const stmtCloseSession = db.prepare(
+    "UPDATE sessions SET closed_at = datetime('now'), refund_preimage = ? WHERE session_id = ? AND closed_at IS NULL"
+  )
+
+  const stmtGetExpiredSessions = db.prepare(
+    "SELECT session_id, payment_hash, balance_sats, deposit_sats, return_invoice, bearer_token, created_at, expires_at, closed_at, refund_preimage FROM sessions WHERE closed_at IS NULL AND expires_at < datetime('now')"
+  )
+
+  const stmtPruneClosedSessions = db.prepare(
+    "DELETE FROM sessions WHERE closed_at IS NOT NULL AND closed_at < datetime('now', '-' || ? || ' seconds')"
+  )
+
+  const stmtGetSessionBalance = db.prepare(
+    'SELECT balance_sats FROM sessions WHERE session_id = ? AND closed_at IS NULL'
+  )
+
+  function rowToSession(row: Record<string, unknown>): Session {
+    return {
+      sessionId: row.session_id as string,
+      paymentHash: row.payment_hash as string,
+      balanceSats: row.balance_sats as number,
+      depositSats: row.deposit_sats as number,
+      returnInvoice: row.return_invoice as string | null,
+      bearerToken: row.bearer_token as string,
+      createdAt: row.created_at as string,
+      expiresAt: row.expires_at as string,
+      closedAt: row.closed_at as string | null,
+      refundPreimage: row.refund_preimage as string | null,
+    }
+  }
+
+  const txnDeductSession = db.transaction((sessionId: string, amount: number): { newBalance: number } => {
+    const row = stmtGetSessionBalance.get(sessionId) as { balance_sats: number } | undefined
+    if (!row) throw new Error(`Session not found or closed: ${sessionId}`)
+    if (row.balance_sats < amount) throw new Error(`Insufficient session balance: ${row.balance_sats} < ${amount}`)
+    stmtDeductSession.run(amount, sessionId, amount)
+    return { newBalance: row.balance_sats - amount }
+  })
+
+  const txnTopUpSession = db.transaction((sessionId: string, amount: number): { newBalance: number } => {
+    const row = stmtGetSessionBalance.get(sessionId) as { balance_sats: number } | undefined
+    if (!row) throw new Error(`Session not found or closed: ${sessionId}`)
+    stmtTopUpSession.run(amount, sessionId)
+    return { newBalance: row.balance_sats + amount }
+  })
+
   const txnDebit = db.transaction((paymentHash: string, amount: number, currency: Currency = 'sat'): DebitResult => {
     const stmtBal = balanceFor(currency)
     const row = stmtBal.get(paymentHash) as { balance: number } | undefined
@@ -460,6 +545,43 @@ export function sqliteStorage(config?: SqliteStorageConfig): StorageBackend {
       total += stmtPruneClaims.run(maxAgeSecs).changes
       return total
     }),
+
+    createSession(session: { sessionId: string, paymentHash: string, balanceSats: number, depositSats: number, bearerToken: string, expiresAt: string, returnInvoice?: string }): void {
+      stmtCreateSession.run(session.sessionId, session.paymentHash, session.balanceSats, session.depositSats, session.bearerToken, session.expiresAt, session.returnInvoice ?? null)
+    },
+
+    getSession(sessionId: string): Session | null {
+      const row = stmtGetSession.get(sessionId) as Record<string, unknown> | undefined
+      return row ? rowToSession(row) : null
+    },
+
+    getSessionByBearer(bearerToken: string): Session | null {
+      const row = stmtGetSessionByBearer.get(bearerToken) as Record<string, unknown> | undefined
+      return row ? rowToSession(row) : null
+    },
+
+    deductSession(sessionId: string, amount: number): { newBalance: number } {
+      return txnDeductSession(sessionId, amount)
+    },
+
+    topUpSession(sessionId: string, amount: number): { newBalance: number } {
+      return txnTopUpSession(sessionId, amount)
+    },
+
+    closeSession(sessionId: string, refundPreimage?: string): void {
+      stmtCloseSession.run(refundPreimage ?? null, sessionId)
+    },
+
+    getExpiredSessions(): Session[] {
+      const rows = stmtGetExpiredSessions.all() as Array<Record<string, unknown>>
+      return rows.map(rowToSession)
+    },
+
+    pruneClosedSessions(maxAgeMs: number): number {
+      const maxAgeSecs = Math.floor(maxAgeMs / 1000)
+      const result = stmtPruneClosedSessions.run(maxAgeSecs)
+      return result.changes
+    },
 
     close(): void {
       db.close()

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,15 @@ export interface LightningBackend {
    * @returns The current invoice status.
    */
   checkInvoice(paymentHash: string): Promise<InvoiceStatus>
+
+  /**
+   * Pay a Lightning invoice (outbound payment).
+   * Required for session intent refunds — not all deployments need this.
+   * Backends that don't support outbound payments should throw.
+   * @param bolt11 - The BOLT11 invoice to pay.
+   * @returns The payment preimage proving payment was made.
+   */
+  sendPayment?(bolt11: string): Promise<{ preimage: string }>
 }
 
 import type { Proof } from '@cashu/cashu-ts'
@@ -111,6 +120,22 @@ export interface IETFPaymentConfig {
   challengeExpirySecs?: number
   /** Human-readable service description for challenges. */
   description?: string
+}
+
+/**
+ * Configuration for the IETF Payment session intent.
+ * Enables deposit/bearer/top-up/close lifecycle for streaming payments.
+ * Requires a Lightning backend that supports `sendPayment()` for refunds.
+ */
+export interface SessionConfig {
+  /** Maximum session duration in milliseconds. Default: 86,400,000 (24 hours). */
+  maxSessionDurationMs?: number
+  /** Maximum deposit amount in satoshis. Default: 100,000. */
+  maxDepositSats?: number
+  /** Interval for sweeping expired sessions in milliseconds. Default: 3,600,000 (1 hour). */
+  sessionPruneIntervalMs?: number
+  /** Balance threshold (sats) below which NeedTopUp events are emitted. Default: 10% of deposit. */
+  needTopUpThresholdSats?: number
 }
 
 /**
@@ -221,6 +246,13 @@ export interface BoothConfig {
    * Requires a Lightning backend for invoice creation.
    */
   ietfPayment?: IETFPaymentConfig
+
+  /**
+   * IETF Payment session intent configuration.
+   * Enables deposit/bearer/top-up/close for streaming payments.
+   * Requires `ietfPayment` and a Lightning backend with `sendPayment()`.
+   */
+  ietfSession?: SessionConfig
 
   /**
    * Human-readable service name used in Lightning invoice descriptions.


### PR DESCRIPTION
## Summary

Implements the IETF Payment session intent (deposit/bearer/top-up/close lifecycle) per the `forgesworn/payment-methods` session specification. This enables streaming payment sessions for use cases like LLM token streaming, ridesharing metering, and real-time data feeds.

**5 commits:**

- **PaymentSender interface** — `sendPayment(bolt11)` on all 5 Lightning backends (Phoenixd, LND, CLN, LNbits, NWC) for outbound refund payments
- **Session storage** — SQLite table with migration, indexes, atomic deduct/topUp transactions + memory implementation
- **Session rail** — `createIETFSessionRail()` factory with full lifecycle (challenge, open, bearer, top-up, close)
- **Engine integration** — `'session'` mode in TollBoothEngine, `deductSession`, `X-Session-Balance` headers, `Cache-Control: private, no-store`
- **Security audit fixes** — 2 CRITICAL + 3 HIGH + 5 MEDIUM addressed

**Compliance guardrails built in:**

- `maxSessionDurationMs` (default 24h) — prevents indefinite custody
- `maxDepositSats` (default 100k sats) — limits value held
- Auto-close sweep for expired sessions with refund
- Refund-to-originator enforcement (no close-time invoice override)
- BOLT11 amount validation before refund payment
- TOCTOU double-refund protection (close-before-pay)
- Cumulative deposit cap on top-ups

**New files:**

- `src/core/ietf-session.ts` — session rail implementation
- `src/core/ietf-session.test.ts` — 26 tests (lifecycle, compliance, security, adversarial)
- `COMPLIANCE.md` — regulatory posture documentation

## Test plan

- [x] 852 tests pass (26 new session-specific, 826 existing)
- [x] TypeScript typecheck clean
- [x] Security audit: 2 CRITICAL, 3 HIGH, 5 MEDIUM fixed
- [x] Full session lifecycle: open -> bearer auth -> deduct -> close -> refund
- [x] Compliance guardrails: max deposit, max duration, auto-close, cap enforcement
- [x] Adversarial: replay, expired challenge, expired session, close replay, sendPayment failure, malformed auth
- [ ] Integration test with live Lightning backend (post-merge)
- [ ] satgate integration (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)